### PR TITLE
browserify doesn't like the relative path

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git://github.com/form-data/form-data.git"
   },
-  "main": "./lib/form_data.js",
+  "main": "lib/form_data.js",
   "browser": "./lib/browser",
   "scripts": {
     "test": "./test/run.js",


### PR DESCRIPTION
Browserify doesn't consume it with the `main` using a relative path. This fixes https://github.com/jaws-framework/JAWS/issues/253.
